### PR TITLE
로고화면다시짬, 프래그먼트 내부에 상하이동가능 분할 바생성

### DIFF
--- a/.idea/deploymentTargetDropDown.xml
+++ b/.idea/deploymentTargetDropDown.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="deploymentTargetDropDown">
+    <targetSelectedWithDropDown>
+      <Target>
+        <type value="QUICK_BOOT_TARGET" />
+        <deviceKey>
+          <Key>
+            <type value="VIRTUAL_DEVICE_PATH" />
+            <value value="C:\Users\82102\.android\avd\Pixel_2_API_30.avd" />
+          </Key>
+        </deviceKey>
+      </Target>
+    </targetSelectedWithDropDown>
+    <timeTargetWasSelectedWithDropDown value="2021-11-02T13:07:43.594495Z" />
+  </component>
+</project>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -4,11 +4,13 @@
     <option name="filePathToZoomLevelMap">
       <map>
         <entry key="..\:/Users/82102/Desktop/mobileTeam/Git-fetch/Mob4/app/src/main/res/drawable/ic_home.xml" value="0.27384615384615385" />
+        <entry key="..\:/Users/82102/Desktop/mobileTeam/Git-fetch/Mob4/app/src/main/res/drawable/splash_background.xml" value="0.28072916666666664" />
         <entry key="..\:/Users/82102/Desktop/mobileTeam/Git-fetch/Mob4/app/src/main/res/layout/activity_main.xml" value="0.17446808510638298" />
         <entry key="..\:/Users/82102/Desktop/mobileTeam/Git-fetch/Mob4/app/src/main/res/layout/activity_start.xml" value="0.13486842105263158" />
-        <entry key="..\:/Users/82102/Desktop/mobileTeam/Git-fetch/Mob4/app/src/main/res/layout/fragment_home.xml" value="0.13541666666666666" />
+        <entry key="..\:/Users/82102/Desktop/mobileTeam/Git-fetch/Mob4/app/src/main/res/layout/fragment_home.xml" value="0.21818181061547676" />
         <entry key="..\:/Users/82102/Desktop/mobileTeam/Git-fetch/Mob4/app/src/main/res/layout/fragment_setting.xml" value="0.1" />
         <entry key="..\:/Users/82102/Desktop/mobileTeam/Git-fetch/Mob4/app/src/main/res/layout/fragment_storage.xml" value="0.17864583333333334" />
+        <entry key="..\:/Users/82102/Desktop/mobileTeam/Git-fetch/Mob4/app/src/main/res/layout/test.xml" value="0.2635416666666667" />
         <entry key="..\:/Users/82102/Desktop/mobileTeam/Git-fetch/Mob4/app/src/main/res/menu/menu.xml" value="0.30520833333333336" />
       </map>
     </option>

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -15,7 +15,15 @@
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 
-                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+        <activity
+            android:name=".SplashActivity"
+            android:theme="@style/SplashTheme"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN"/>
+                <category android:name="android.intent.category.LAUNCHER"/>
             </intent-filter>
         </activity>
     </application>

--- a/app/src/main/java/com/application/mob4git/FragmentHome.java
+++ b/app/src/main/java/com/application/mob4git/FragmentHome.java
@@ -2,17 +2,61 @@ package com.application.mob4git;
 
 import android.os.Bundle;
 import android.view.LayoutInflater;
+import android.view.MotionEvent;
 import android.view.View;
 import android.view.ViewGroup;
+import android.widget.Button;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.fragment.app.Fragment;
 
-public class FragmentHome extends Fragment {
+public class FragmentHome extends Fragment implements View.OnTouchListener{
+
+    View mainView;
+    View divider;
+    float oldYvalue;
+    Button button_horizontal;
+    Button button_vertical;
+
     @Nullable
     @Override
     public View onCreateView(@NonNull LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState) {
-        return inflater.inflate(R.layout.fragment_home, container, false);
+        mainView = inflater.inflate(R.layout.fragment_home, container, false);
+        divider = mainView.findViewById(R.id.divider);
+        button_horizontal = mainView.findViewById(R.id.button_horizontal);
+        button_vertical = mainView.findViewById(R.id.button_vertical);
+
+        divider.setOnTouchListener(this);
+
+
+
+        return mainView;
+
+    }
+
+
+    @Override
+    public boolean onTouch(View v, MotionEvent event) {
+        int height = ((ViewGroup) v.getParent()).getHeight() - v.getHeight();
+
+        if(event.getAction() == MotionEvent.ACTION_DOWN){
+            oldYvalue = event.getY();
+        }else if(event.getAction() == MotionEvent.ACTION_MOVE){
+            v.setY(event.getRawY()-(oldYvalue+v.getHeight()));
+        }else if(event.getAction() == MotionEvent.ACTION_UP){
+            if(v.getY() > height-400){
+                v.setY(height-400);
+            }else if(v.getY() <400){
+                v.setY(400);
+            }else if(v.getY() <0 || v.getY() > height){
+                if(v.getY() < 0){
+                    v.setY(400);
+                }else{
+                    v.setY(height-400);
+                }
+            }
+        }
+        return true;
     }
 }

--- a/app/src/main/java/com/application/mob4git/FragmentSettings.java
+++ b/app/src/main/java/com/application/mob4git/FragmentSettings.java
@@ -2,6 +2,7 @@ package com.application.mob4git;
 
 import android.os.Bundle;
 import android.view.LayoutInflater;
+import android.view.MotionEvent;
 import android.view.View;
 import android.view.ViewGroup;
 
@@ -9,10 +10,43 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.fragment.app.Fragment;
 
-public class FragmentSettings extends Fragment {
+public class FragmentSettings extends Fragment implements View.OnTouchListener{
+    View mainView;
+    View divider;
+    float oldYvalue;
+
     @Nullable
     @Override
     public View onCreateView(@NonNull LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState) {
-        return inflater.inflate(R.layout.fragment_setting, container, false);
+        mainView = inflater.inflate(R.layout.fragment_setting, container, false);
+        divider = mainView.findViewById(R.id.divider);
+        divider.setOnTouchListener(this);
+
+        return mainView;
+    }
+
+
+    @Override
+    public boolean onTouch(View v, MotionEvent event) {
+        int height = ((ViewGroup) v.getParent()).getHeight() - v.getHeight();
+
+        if(event.getAction() == MotionEvent.ACTION_DOWN){
+            oldYvalue = event.getY();
+        }else if(event.getAction() == MotionEvent.ACTION_MOVE){
+            v.setY(event.getRawY()-(oldYvalue+v.getHeight()));
+        }else if(event.getAction() == MotionEvent.ACTION_UP){
+            if(v.getY() > height-400){
+                v.setY(height-400);
+            }else if(v.getY() <400){
+                v.setY(400);
+            }else if(v.getY() <0 || v.getY() > height){
+                if(v.getY() < 0){
+                    v.setY(400);
+                }else{
+                    v.setY(height-400);
+                }
+            }
+        }
+        return true;
     }
 }

--- a/app/src/main/java/com/application/mob4git/FragmentStorage.java
+++ b/app/src/main/java/com/application/mob4git/FragmentStorage.java
@@ -2,6 +2,7 @@ package com.application.mob4git;
 
 import android.os.Bundle;
 import android.view.LayoutInflater;
+import android.view.MotionEvent;
 import android.view.View;
 import android.view.ViewGroup;
 
@@ -9,10 +10,42 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.fragment.app.Fragment;
 
-public class FragmentStorage extends Fragment {
+public class FragmentStorage extends Fragment implements View.OnTouchListener{
+    View mainView;
+    View divider;
+    float oldYvalue;
+
     @Nullable
     @Override
     public View onCreateView(@NonNull LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState) {
-        return inflater.inflate(R.layout.fragment_storage, container, false);
+        mainView = inflater.inflate(R.layout.fragment_storage, container, false);
+        divider = mainView.findViewById(R.id.divider);
+        divider.setOnTouchListener(this);
+
+        return mainView;
+    }
+
+    @Override
+    public boolean onTouch(View v, MotionEvent event) {
+        int height = ((ViewGroup) v.getParent()).getHeight() - v.getHeight();
+
+        if(event.getAction() == MotionEvent.ACTION_DOWN){
+            oldYvalue = event.getY();
+        }else if(event.getAction() == MotionEvent.ACTION_MOVE){
+            v.setY(event.getRawY()-(oldYvalue+v.getHeight()));
+        }else if(event.getAction() == MotionEvent.ACTION_UP){
+            if(v.getY() > height-400){
+                v.setY(height-400);
+            }else if(v.getY() <400){
+                v.setY(400);
+            }else if(v.getY() <0 || v.getY() > height){
+                if(v.getY() < 0){
+                    v.setY(400);
+                }else{
+                    v.setY(height-400);
+                }
+            }
+        }
+        return true;
     }
 }

--- a/app/src/main/java/com/application/mob4git/MainActivity.java
+++ b/app/src/main/java/com/application/mob4git/MainActivity.java
@@ -6,14 +6,20 @@ import androidx.appcompat.app.AppCompatActivity;
 import androidx.fragment.app.FragmentManager;
 import androidx.fragment.app.FragmentTransaction;
 
+import android.graphics.PointF;
+import android.os.Build;
 import android.os.Bundle;
 import android.view.MenuItem;
+import android.view.MotionEvent;
 import android.view.View;
+import android.view.ViewGroup;
+import android.widget.Button;
 import android.widget.ImageView;
+import android.widget.TextView;
 
 import com.google.android.material.bottomnavigation.BottomNavigationView;
 
-public class MainActivity extends AppCompatActivity {
+public class MainActivity extends AppCompatActivity{
 
     private FragmentManager fragmentManager = getSupportFragmentManager();
     private FragmentHome fragmentHome = new FragmentHome();
@@ -26,37 +32,15 @@ public class MainActivity extends AppCompatActivity {
         setContentView(R.layout.activity_main);
 
 
-        //앱을 처음켰을때 대표적 화면 나오고 2.5초뒤에 사라지고 화면나오게하기
-        if (savedInstanceState == null) {
-            ImageView ImageView_Logo = findViewById(R.id.ImageView_Logo);
-            ImageView_Logo.setVisibility(View.VISIBLE);
-            // 네비게이션바 숨기기
-
-            BottomNavigationView BNView = findViewById(R.id.navigationView);
-            BNView.setVisibility(View.INVISIBLE);
-            // 툴바 숨기기
-            ActionBar actionBar = getSupportActionBar();
-            if (actionBar != null) {
-                actionBar.hide();
-            }
-
-            //화면 2.5초 나오게하고 사라지기
-            ImageView_Logo.postDelayed(() -> {     //delay뒤에 실행 할 코드
-                ImageView_Logo.setVisibility(View.INVISIBLE);
-                // 툴바,네비게이션뷰 보이게
-                if (actionBar != null) {
-                    actionBar.show();
-                    BNView.setVisibility(View.VISIBLE);
-                }
-            }, 2500);
-        }
-
-        //시작하자마자 나오는 홈 화면에 HomeFragme이 실행되게끔하는코드
+        //시작하자마자 나오는 홈 화면에 HomeFragment이 실행되게끔하는코드
         FragmentTransaction transaction = fragmentManager.beginTransaction();
         transaction.replace(R.id.frameLayout, fragmentHome).commitAllowingStateLoss();
 
         BottomNavigationView BNView = findViewById(R.id.navigationView);
         BNView.setOnNavigationItemSelectedListener(new ItemSelectedListener());
+
+
+
     }
 
     class ItemSelectedListener implements BottomNavigationView.OnNavigationItemSelectedListener{

--- a/app/src/main/java/com/application/mob4git/SplashActivity.java
+++ b/app/src/main/java/com/application/mob4git/SplashActivity.java
@@ -1,0 +1,18 @@
+package com.application.mob4git;
+
+import android.content.Intent;
+import android.os.Bundle;
+
+import androidx.annotation.Nullable;
+import androidx.appcompat.app.AppCompatActivity;
+
+public class SplashActivity extends AppCompatActivity {
+    @Override
+    protected void onCreate(@Nullable Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+
+        Intent intent = new Intent(this, MainActivity.class);
+        startActivity(intent);
+        finish();
+    }
+}

--- a/app/src/main/res/drawable/splash_background.xml
+++ b/app/src/main/res/drawable/splash_background.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+    <item
+        android:drawable="@color/cardview_shadow_end_color"/>
+    <item>
+        <bitmap
+            android:gravity="center"
+            android:src="@drawable/zoommatelogo"/>
+    </item>
+</layer-list>

--- a/app/src/main/res/layout/fragment_home.xml
+++ b/app/src/main/res/layout/fragment_home.xml
@@ -1,17 +1,43 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
-    <TextView
-        android:id="@+id/textView2"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:text="홈"
-        android:textSize="50sp"
+
+    <View
+        android:id="@+id/divider"
+        android:layout_width="409dp"
+        android:layout_height="5dp"
+        android:background="#BB000000"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
+
+    <Button
+        android:id="@+id/button_horizontal"
+        android:layout_width="110dp"
+        android:layout_height="110dp"
+        android:layout_below="@+id/divider"
+        android:layout_marginStart="64dp"
+        android:layout_marginTop="84dp"
+        android:text="가로"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/divider" />
+
+    <Button
+        android:id="@+id/button_vertical"
+        android:layout_width="110dp"
+        android:layout_height="110dp"
+        android:layout_below="@+id/divider"
+        android:layout_marginTop="84dp"
+        android:text="세로"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHorizontal_bias="0.536"
+        app:layout_constraintStart_toEndOf="@+id/button_horizontal"
+        app:layout_constraintTop_toBottomOf="@+id/divider" />
+
+
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_setting.xml
+++ b/app/src/main/res/layout/fragment_setting.xml
@@ -15,4 +15,16 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
+
+    <View
+        android:id="@+id/divider"
+        android:layout_width="409dp"
+        android:layout_height="8dp"
+        android:background="#CC000000"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_storage.xml
+++ b/app/src/main/res/layout/fragment_storage.xml
@@ -7,11 +7,21 @@
 
 
     <TextView
-        android:id="@+id/textView"
+        android:id="@+id/textView2"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:text="저장소"
         android:textSize="50sp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <View
+        android:id="@+id/divider"
+        android:layout_width="409dp"
+        android:layout_height="8dp"
+        android:background="#CC000000"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+
+    <style name="SplashTheme" parent="Theme.AppCompat.NoActionBar">
+        <item name="android:windowBackground">@drawable/splash_background</item>
+    </style>
+</resources>


### PR DESCRIPTION
로고화면위에 메인프래그먼트의 내용물이 보이는 문제가 발생했고.
해결과정을 찾는도중 로고화면을 SplashActivity로 따로 작성하여 기능하게하면 해결된다는걸 알게되어 변경,
그리고 세로모드의 기능중 하나인 상 하 화면 분할 바를 onTouchListener로 구현
그러나 첫화면의 가로, 세로 버튼이 분할바의 상, 하 움직임에 따라 같이 이동해야하는 부분은 아직 미구현